### PR TITLE
Ensure future compatibility with Quarkus 3.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <assertj-core.version>3.24.2</assertj-core.version>
     <weld.version>5.1.2.Final</weld.version>
     <testcontainers-solace.version>1.18.3</testcontainers-solace.version>
+    <slf4j-log4j12.version>2.0.7</slf4j-log4j12.version>
   </properties>
 
   <dependencyManagement>
@@ -74,6 +75,12 @@
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj-core.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-log4j12</artifactId>
+        <version>${slf4j-log4j12.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/quarkus-solace-client/runtime/pom.xml
+++ b/quarkus-solace-client/runtime/pom.xml
@@ -31,6 +31,12 @@
     </dependency>
   </dependencies>
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>io.quarkus</groupId>

--- a/quarkus-solace-messaging-connector/runtime/pom.xml
+++ b/quarkus-solace-messaging-connector/runtime/pom.xml
@@ -139,6 +139,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- Fix version of slf4j-log4j12 test dependency
- Configure resource filtering for extension metadata ids
- Avoid using custom message type SolaceInboundMessage injection in consume methods