### PR TITLE
Turn off graceful shutdown for connector tests by default

### DIFF
--- a/quarkus-solace-messaging-connector/runtime/pom.xml
+++ b/quarkus-solace-messaging-connector/runtime/pom.xml
@@ -12,10 +12,6 @@
     <name>Quarkus Solace Messaging Connector - Runtime</name>
     <dependencies>
         <dependency>
-            <groupId>io.smallrye.config</groupId>
-            <artifactId>smallrye-config</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
         </dependency>

--- a/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/SolaceConsumerTest.java
+++ b/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/SolaceConsumerTest.java
@@ -46,7 +46,7 @@ public class SolaceConsumerTest extends WeldTestBase {
     @Test
     @Order(1)
     void consumer() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.incoming.in.connector", "quarkus-solace")
                 .with("mp.messaging.incoming.in.consumer.queue.name", queue)
                 .with("mp.messaging.incoming.in.consumer.queue.add-additional-subscriptions", "true")
@@ -74,7 +74,7 @@ public class SolaceConsumerTest extends WeldTestBase {
     @Test
     @Order(2)
     void consumerReplay() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.incoming.in.connector", "quarkus-solace")
                 .with("mp.messaging.incoming.in.consumer.queue.name", queue)
                 .with("mp.messaging.incoming.in.consumer.queue.type", "durable-exclusive")
@@ -94,7 +94,7 @@ public class SolaceConsumerTest extends WeldTestBase {
     @Test
     @Order(3)
     void consumerWithSelectorQuery() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.incoming.in.connector", "quarkus-solace")
                 .with("mp.messaging.incoming.in.consumer.queue.name", queue)
                 .with("mp.messaging.incoming.in.consumer.queue.add-additional-subscriptions", "true")
@@ -124,7 +124,7 @@ public class SolaceConsumerTest extends WeldTestBase {
     @Test
     @Order(4)
     void consumerFailedProcessingPublishToErrorTopic() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.incoming.in.connector", "quarkus-solace")
                 .with("mp.messaging.incoming.in.consumer.queue.name", SolaceContainer.INTEGRATION_TEST_QUEUE_NAME)
                 .with("mp.messaging.incoming.in.consumer.queue.type", "durable-exclusive")
@@ -158,7 +158,7 @@ public class SolaceConsumerTest extends WeldTestBase {
     @Test
     @Order(5)
     void consumerFailedProcessingMoveToDMQ() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.incoming.in.connector", "quarkus-solace")
                 .with("mp.messaging.incoming.in.consumer.queue.name", SolaceContainer.INTEGRATION_TEST_QUEUE_NAME)
                 .with("mp.messaging.incoming.in.consumer.queue.type", "durable-exclusive")
@@ -193,7 +193,7 @@ public class SolaceConsumerTest extends WeldTestBase {
     @Test
     @Order(6)
     void partitionedQueue() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.incoming.consumer-1.connector", "quarkus-solace")
                 .with("mp.messaging.incoming.consumer-1.consumer.queue.name",
                         SolaceContainer.INTEGRATION_TEST_PARTITION_QUEUE_NAME)
@@ -262,7 +262,7 @@ public class SolaceConsumerTest extends WeldTestBase {
     @Test
     @Order(7)
     void consumerPublishToErrorTopicPermissionException() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.incoming.in.connector", "quarkus-solace")
                 .with("mp.messaging.incoming.in.consumer.queue.name", SolaceContainer.INTEGRATION_TEST_QUEUE_NAME)
                 .with("mp.messaging.incoming.in.consumer.queue.type", "durable-exclusive")
@@ -340,7 +340,7 @@ public class SolaceConsumerTest extends WeldTestBase {
     @Test
     @Order(9)
     void consumerCreateMissingResourceAddSubscriptionPermissionException() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.incoming.in.connector", "quarkus-solace")
                 .with("mp.messaging.incoming.in.consumer.queue.add-additional-subscriptions", "true")
                 .with("mp.messaging.incoming.in.consumer.queue.missing-resource-creation-strategy", "create-on-start")

--- a/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/SolaceProcessorTest.java
+++ b/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/SolaceProcessorTest.java
@@ -28,7 +28,7 @@ public class SolaceProcessorTest extends WeldTestBase {
     @Test
     void consumer() {
         String processedTopic = topic + "/processed";
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.incoming.in.connector", "quarkus-solace")
                 .with("mp.messaging.incoming.in.consumer.queue.add-additional-subscriptions", "true")
                 .with("mp.messaging.incoming.in.consumer.queue.missing-resource-creation-strategy", "create-on-start")

--- a/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/SolacePublisherTest.java
+++ b/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/SolacePublisherTest.java
@@ -30,7 +30,7 @@ public class SolacePublisherTest extends WeldTestBase {
 
     @Test
     void publisher() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.outgoing.out.connector", "quarkus-solace")
                 .with("mp.messaging.outgoing.out.producer.topic", topic);
 
@@ -53,7 +53,7 @@ public class SolacePublisherTest extends WeldTestBase {
 
     @Test
     void publisherWithDynamicDestination() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.outgoing.out.connector", "quarkus-solace")
                 .with("mp.messaging.outgoing.out.producer.topic", topic);
 
@@ -80,7 +80,7 @@ public class SolacePublisherTest extends WeldTestBase {
 
     @Test
     void publisherWithBackPressureReject() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.outgoing.out.connector", "quarkus-solace")
                 .with("mp.messaging.outgoing.out.producer.topic", topic)
                 .with("mp.messaging.outgoing.out.producer.back-pressure.buffer-capacity", 1);

--- a/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/base/SolaceBrokerExtension.java
+++ b/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/base/SolaceBrokerExtension.java
@@ -44,7 +44,7 @@ public class SolaceBrokerExtension implements BeforeAllCallback, ParameterResolv
     public void startSolaceBroker() {
         solace = createSolaceContainer()
                 .withCredentials("user", "pass")
-                .withExposedPorts(SolaceContainer.Service.SMF.getPort())
+                .withExposedPorts(SolaceContainer.Service.SMF.getPort(), 8080)
                 .withPublishTopic("quarkus/integration/test/replay/messages", SolaceContainer.Service.SMF)
                 .withPublishTopic("quarkus/integration/test/default/>", SolaceContainer.Service.SMF)
                 .withPublishTopic("quarkus/integration/test/provisioned/>", SolaceContainer.Service.SMF)

--- a/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/base/WeldTestBase.java
+++ b/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/base/WeldTestBase.java
@@ -139,4 +139,9 @@ public class WeldTestBase extends SolaceBaseTest {
         return getHealth().getLiveness().isOk();
     }
 
+    public MapBasedConfig commonConfig() {
+        return new MapBasedConfig()
+                .with("mp.messaging.connector.quarkus-solace.client.graceful-shutdown", false);
+    }
+
 }

--- a/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/health/SolacePublisherHealthTest.java
+++ b/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/health/SolacePublisherHealthTest.java
@@ -22,7 +22,7 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
 
-public class SolacePublisherHealthCheck extends WeldTestBase {
+public class SolacePublisherHealthTest extends WeldTestBase {
     @Test
     void publisherHealthCheck() {
         MapBasedConfig config = new MapBasedConfig()
@@ -73,7 +73,9 @@ public class SolacePublisherHealthCheck extends WeldTestBase {
         // Run app that publish messages
         MyApp app = runApplication(config, MyApp.class);
 
-        await().until(() -> isStarted() && isReady());
+        await().until(() -> isStarted() && isReady() && !isAlive());
+
+        await().until(() -> !isAlive());
 
         HealthReport startup = getHealth().getStartup();
         HealthReport liveness = getHealth().getLiveness();
@@ -94,7 +96,6 @@ public class SolacePublisherHealthCheck extends WeldTestBase {
 
         @Outgoing("out")
         Multi<Message<String>> out() {
-
             return Multi.createFrom().items("1", "2", "3", "4", "5")
                     .map(payload -> Message.of(payload).withAck(() -> {
                         acked.add(payload);

--- a/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/locals/LocalPropagationAckTest.java
+++ b/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/locals/LocalPropagationAckTest.java
@@ -28,7 +28,7 @@ import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
 public class LocalPropagationAckTest extends WeldTestBase {
 
     private MapBasedConfig dataconfig() {
-        return new MapBasedConfig()
+        return commonConfig()
                 .with("mp.messaging.incoming.data.connector", SolaceConnector.CONNECTOR_NAME)
                 .with("mp.messaging.incoming.data.consumer.queue.subscriptions", topic)
                 .with("mp.messaging.incoming.data.consumer.queue.add-additional-subscriptions", "true")

--- a/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/locals/LocalPropagationTest.java
+++ b/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/locals/LocalPropagationTest.java
@@ -39,7 +39,7 @@ import io.vertx.mutiny.core.Vertx;
 public class LocalPropagationTest extends WeldTestBase {
 
     private MapBasedConfig dataconfig() {
-        return new MapBasedConfig()
+        return commonConfig()
                 .with("mp.messaging.incoming.data.connector", SolaceConnector.CONNECTOR_NAME)
                 .with("mp.messaging.incoming.data.consumer.queue.subscriptions", topic)
                 .with("mp.messaging.incoming.data.consumer.queue.add-additional-subscriptions", "true")

--- a/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/perf/EndToEndPerformanceTest.java
+++ b/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/perf/EndToEndPerformanceTest.java
@@ -37,7 +37,7 @@ public class EndToEndPerformanceTest extends WeldTestBase {
     @Test
     public void endToEndPerformanceTesttWithBackPressureWaitAndWaitForPublishReceipt() {
         String processedTopic = topic + "/processed";
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.incoming.in.connector", "quarkus-solace")
                 .with("mp.messaging.incoming.in.consumer.queue.name", queue)
                 .with("mp.messaging.incoming.in.consumer.queue.add-additional-subscriptions", "true")

--- a/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/perf/SolaceConsumerPerformanceTest.java
+++ b/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/perf/SolaceConsumerPerformanceTest.java
@@ -31,13 +31,12 @@ public class SolaceConsumerPerformanceTest extends WeldTestBase {
                 .build()
                 .start();
 
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.incoming.in.connector", "quarkus-solace")
                 .with("mp.messaging.incoming.in.consumer.queue.name", queue)
                 .with("mp.messaging.incoming.in.consumer.queue.add-additional-subscriptions", "true")
                 .with("mp.messaging.incoming.in.consumer.queue.missing-resource-creation-strategy", "create-on-start")
                 .with("mp.messaging.incoming.in.consumer.queue.subscriptions", topic);
-        //                .with("mp.messaging.incoming.in.client.graceful-shutdown", false);
 
         // Run app that consumes messages
         MyConsumer app = runApplication(config, MyConsumer.class);

--- a/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/perf/SolacePublisherPerformanceTest.java
+++ b/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/perf/SolacePublisherPerformanceTest.java
@@ -28,7 +28,7 @@ public class SolacePublisherPerformanceTest extends WeldTestBase {
 
     @Test
     void publisherPerformanceTestWithBackPressureWaitAndWaitForPublishReceipt() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.outgoing.out.connector", "quarkus-solace")
                 .with("mp.messaging.outgoing.out.producer.topic", topic);
 
@@ -65,7 +65,7 @@ public class SolacePublisherPerformanceTest extends WeldTestBase {
 
     @Test
     void publisherPerformanceTestWithBackPressureWaitAndNoWaitForPublishReceipt() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.outgoing.out.connector", "quarkus-solace")
                 .with("mp.messaging.outgoing.out.producer.topic", topic)
                 .with("mp.messaging.outgoing.out.producer.waitForPublishReceipt", false);
@@ -103,7 +103,7 @@ public class SolacePublisherPerformanceTest extends WeldTestBase {
 
     @Test
     void publisherPerformanceTestWithBackPressureElasticAndWaitForPublishReceipt() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.outgoing.out.connector", "quarkus-solace")
                 .with("mp.messaging.outgoing.out.producer.topic", topic)
                 .with("mp.messaging.outgoing.out.producer.back-pressure.strategy", "elastic");
@@ -141,7 +141,7 @@ public class SolacePublisherPerformanceTest extends WeldTestBase {
 
     @Test
     void publisherPerformanceTestWithBackPressureElasticAndNoWaitForPublishReceipt() {
-        MapBasedConfig config = new MapBasedConfig()
+        MapBasedConfig config = commonConfig()
                 .with("mp.messaging.outgoing.out.connector", "quarkus-solace")
                 .with("mp.messaging.outgoing.out.producer.topic", topic)
                 .with("mp.messaging.outgoing.out.producer.back-pressure.strategy", "elastic")


### PR DESCRIPTION
Rename Solace publisher health test to enable it