### PR TITLE
added file to avoid running published files through jekyll

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,38 @@
+# see https://github.com/actions/starter-workflows/blob/main/pages/jekyll.yml for reference
+name: Publish to GitHub Pages
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Generate Site
+        run: mvn clean install -DskipTests
+      - name: Upload Artifacts
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: "docs/target/generated-docs/"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Samples folder has examples on how to use the connector - [solace-connector-samp
 
 ## Documentation
 
-The documentation for this extension should be maintained as part of this repository and it is stored in the docs/ directory.
+The documentation for this extension should be maintained as part of this repository and it is stored in the `docs/` directory.
 
 ## Running the extension
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Samples folder has examples on how to use the connector - [solace-connector-samp
 
 ## Documentation
 
-The documentation for this extension should be maintained as part of this repository. Please refer to [Documentation](docs/modules/ROOT/pages/index.adoc) for more details
+The documentation for this extension should be maintained as part of this repository and it is stored in the docs/ directory.
 
 ## Running the extension
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Samples folder has examples on how to use the connector - [solace-connector-samp
 
 ## Documentation
 
-The documentation for this extension should be maintained as part of this repository and it is stored in the `docs/` directory.
+The documentation for this extension should be maintained as part of this repository. Please refer to [Documentation](docs/modules/ROOT/pages/index.adoc) for more details
 
 ## Running the extension
 


### PR DESCRIPTION
Antora docs recommend to add .nojekyll file so that antora docs are properly displayed on github pages

https://docs.antora.org/antora/latest/publish-to-github-pages/#nojekyll