### PR TITLE
Run solace container with a non-root user for podman compatibility

### DIFF
--- a/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/base/SolaceContainer.java
+++ b/quarkus-solace-messaging-connector/runtime/src/test/java/com/solace/quarkus/messaging/base/SolaceContainer.java
@@ -14,7 +14,6 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
-import com.github.dockerjava.api.model.Ulimit;
 
 public class SolaceContainer extends GenericContainer<SolaceContainer> {
 
@@ -65,7 +64,11 @@ public class SolaceContainer extends GenericContainer<SolaceContainer> {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
         withCreateContainerCmdModifier(cmd -> {
-            cmd.getHostConfig().withShmSize(SHM_SIZE).withUlimits(new Ulimit[] { new Ulimit("nofile", 2448L, 6592L) });
+            cmd.withUser("1000");
+            cmd.getHostConfig()
+                    .withShmSize(SHM_SIZE)
+                    .withMemorySwap(-1L)
+                    .withMemoryReservation(0L);
         });
         this.waitStrategy = Wait.forLogMessage(SOLACE_READY_MESSAGE, 1).withStartupTimeout(Duration.ofSeconds(60));
         withExposedPorts(8080);
@@ -82,6 +85,7 @@ public class SolaceContainer extends GenericContainer<SolaceContainer> {
 
     @Override
     protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        executeCommand("chown 1000:0 -R /var/lib/solace");
         if (withClientCert) {
             executeCommand("cp", "/tmp/solace.pem", "/usr/sw/jail/certs/solace.pem");
             executeCommand("cp", "/tmp/rootCA.crt", "/usr/sw/jail/certs/rootCA.crt");


### PR DESCRIPTION
The user gets ownership of the `/var/lib/solace` directory

Should fix #55

For info with podman I can run a Solace container with the following command:
```bash
podman run --rm -it -u 1000 -p 8080:8080 -p 55555 --shm-size=1g \                                                                                                                       
--env username_admin_globalaccesslevel=admin \
--env username_admin_password=admin \
--mount type=tmpfs,destination=/var/lib/solace,ro=false,U=true \
docker.io/solace/solace-pubsub-standard:latest
```