### PR TITLE
Flatten Pom prior to release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup
 release.properties
+**/.flattened-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,15 @@
             </compilerArgs>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>flatten-maven-plugin</artifactId>
+          <version>1.6.0</version>
+          <configuration>
+            <flattenMode>ossrh</flattenMode>
+            <updatePomFile>true</updatePomFile>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -114,6 +123,27 @@
             <id>parse-version</id>
             <goals>
               <goal>parse-version</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <!-- ensure proper cleanup -->
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Flattens pom, this resolves all the variables so that there are version numbers instead of references in the final pom

I've tested, flattened pom still passes maven central validation rules. A [0.2.0 release is available in the staging area](https://s01.oss.sonatype.org/content/repositories/comsolace-1090/)
