### PR TITLE
Fix Oauth token refresh & Quarkus Log exception

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -123,6 +123,7 @@ quarkus.solace.vpn=default
 quarkus.solace.authentication.scheme=AUTHENTICATION_SCHEME_OAUTH2
 quarkus.solace.oidc.client-name=solace // client name provided in oidc client config below
 quarkus.solace.oidc.refresh.interval=50s // Refresh interval should be less than access token expiry time. Otherwise extension will fail to update access token in solace session.
+quarkus.solace.oidc.refresh.timeout=10s // Token Refresh API timeout. Default is set to 10 seconds.
 
 quarkus.oidc-client.solace.auth-server-url=http://localhost:7777/auth/realms/master
 quarkus.oidc-client.solace.client-id=<client-id>
@@ -142,6 +143,7 @@ quarkus.solace.tls.trust-store-type=
 quarkus.solace.tls.trust-store-password=
 quarkus.solace.oidc.client-name=solace // client name provided in oidc client config below
 quarkus.solace.oidc.refresh.interval=50s // Refresh interval should be less than access token expiry time. Otherwise extension will fail to update access token in solace session.
+quarkus.solace.oidc.refresh.timeout=10s // Token Refresh API timeout. Default is set to 10 seconds.
 
 quarkus.oidc-client.solace.auth-server-url=http://localhost:7777/auth/realms/master
 quarkus.oidc-client.solace.client-id=<client-id>

--- a/quarkus-solace-client/runtime/src/main/java/com/solace/quarkus/runtime/OidcProvider.java
+++ b/quarkus-solace-client/runtime/src/main/java/com/solace/quarkus/runtime/OidcProvider.java
@@ -42,15 +42,11 @@ public class OidcProvider {
         return firstToken;
     }
 
+    // @Todo Check if refresh interval is required as token is updated during reconnect in SolaceRecorder.java file. Need to be removed after proper analysis of corner cases.
     void init(MessagingService service) {
         OidcClient client = getClient();
         Multi.createFrom().ticks().every(duration)
                 .emitOn(Infrastructure.getDefaultWorkerPool())
-                //                .filter(x -> {
-                //                    return lastToken == null
-                //                            || lastToken.getRefreshTokenTimeSkew() == null
-                //                            || lastToken.isAccessTokenWithinRefreshInterval();
-                //                })
                 .call(() -> {
                     if (lastToken != null && lastToken.getRefreshToken() != null
                             && lastToken.isAccessTokenWithinRefreshInterval()) {

--- a/quarkus-solace-client/runtime/src/main/java/com/solace/quarkus/runtime/OidcProvider.java
+++ b/quarkus-solace-client/runtime/src/main/java/com/solace/quarkus/runtime/OidcProvider.java
@@ -33,8 +33,6 @@ public class OidcProvider {
 
     private volatile Tokens lastToken;
 
-    private MessagingService service;
-
     Tokens getToken() {
         OidcClient client = getClient();
         Tokens firstToken = client.getTokens().await().indefinitely();
@@ -75,10 +73,6 @@ public class OidcProvider {
     OidcClient getClient() {
         return oidcClientName.map(clients::getClient)
                 .orElseGet(clients::getClient);
-    }
-
-    public Tokens getLastToken() {
-        return lastToken;
     }
 
 }

--- a/quarkus-solace-client/runtime/src/main/java/com/solace/quarkus/runtime/OidcProvider.java
+++ b/quarkus-solace-client/runtime/src/main/java/com/solace/quarkus/runtime/OidcProvider.java
@@ -40,7 +40,6 @@ public class OidcProvider {
         return firstToken;
     }
 
-    // @Todo Check if refresh interval is required as token is updated during reconnect in SolaceRecorder.java file. Need to be removed after proper analysis of corner cases.
     void init(MessagingService service) {
         OidcClient client = getClient();
         Multi.createFrom().ticks().every(duration)

--- a/quarkus-solace-client/runtime/src/main/java/com/solace/quarkus/runtime/SolaceRecorder.java
+++ b/quarkus-solace-client/runtime/src/main/java/com/solace/quarkus/runtime/SolaceRecorder.java
@@ -74,6 +74,7 @@ public class SolaceRecorder {
                     }
                 });
 
+                // Update access token on reconnect to make sure invalid token is not sent. This can happen when a reconnection happens event before scheduled token expiry.
                 service.addReconnectionAttemptListener(serviceEvent -> {
                     Log.info("Reconnecting to Solace broker due to " + serviceEvent.getMessage());
                     if (oidcProvider != null && authScheme != null && "AUTHENTICATION_SCHEME_OAUTH2".equals(authScheme)) {


### PR DESCRIPTION
@ozangunalp - To validate the OAuth token refresh issue, i have left the extension to run since morning and i haven't seen the issue of disconnection. Integration test is not added as we were seeing this issue after few hours.

My observation during testing.
1. Buffer overflow - Ideally this will not occur in real use as user need to set the interval so that only one request is made before token expiry. If they are setting smaller intervals then buffer might overflow due to large number of requests.
2. Solace Reconnection - Reconnection might happen on idle connections depending on keep alive configuration. To avoid unauthorised token we are updating the token based on Solace Reconnect Listener interface.
3. Removed the filter cause in Token refresh method and updated the call method as it already has if condition check.

On Quarkus Log exception since we were not able to reproduce I have added empty beans.xml as recommended by you